### PR TITLE
Removing the requirement for Twilio SDK 3.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "parfumix/laravel5-twilio",
+    "name": "csmillie/laravel5-twilio",
     "type": "library",
     "description": "An laravel5 twilio component decorator.",
     "keywords": ["laravel5", "twilio"],

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "5.0.*",
-        "twilio/sdk":"3.12.*"
+        "twilio/sdk":"4.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "csmillie/laravel5-twilio",
+    "name": "parfumix/laravel5-twilio",
     "type": "library",
     "description": "An laravel5 twilio component decorator.",
     "keywords": ["laravel5", "twilio"],

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,5 @@
         "psr-4": {
             "Twilio\\": "src/Twilio"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "parfumix/laravel5-twilio",
+    "name": "csmillie/laravel5-twilio",
     "type": "library",
     "description": "An laravel5 twilio component decorator.",
     "keywords": ["laravel5", "twilio"],
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*",
+        "illuminate/support": "5.*",
         "twilio/sdk":"4.*"
     },
     "autoload": {


### PR DESCRIPTION
Twilio SDK 4.x is out and 5.x has a release candidate.  I'm not seeing any issues with using 4.x SDK and I'd suggest adjusting to 4.x for now.
